### PR TITLE
docs(readme): add a step to fail on findings in the common workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Report natspec smells findings
+        id: natspec-smells-action
         uses: SmarDex-Ecosystem/natspec-smells-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./
           update-comment: true
+
+      # if the workflow needs to fail, add this step
+      - name: Fail on findings
+        if: ${{ steps.natspec-smells-action.outputs.total-smells > 0 }}
+        run: exit 1
 ```
 
 _Note:_ Only the `pull_request` and `pull_request_target` events are supported.


### PR DESCRIPTION
This PR adds a step to the common workflow in the readme to make the build fail if a NatSpec smell is found.
This step is optional and can be removed if undesired.